### PR TITLE
`findFont` errs on first unfound directory

### DIFF
--- a/src/Graphics/Text/TrueType/FontFolders.hs
+++ b/src/Graphics/Text/TrueType/FontFolders.hs
@@ -234,6 +234,9 @@ findFont loader fontName fontStyle = do
         subRez <- searchIn [(s, n </> s) | s <- sub]
         findOrRest subRez
       else do
-        font <- loader n
-        findOrRest $ font >>= isMatching n
+        isFile <- doesFileExist n
+        if isFile then do
+          font <- loader n
+          findOrRest $ font >>= isMatching n
+        else searchIn rest
 


### PR DESCRIPTION
This fixes an error where `findFont` would attempt to read a directory (that does not exist) as a file.