### PR TITLE
Set up loadParseFontsConf to use an xml-based parser for /etc/fonts/fonts.conf

### DIFF
--- a/FontyFruity.cabal
+++ b/FontyFruity.cabal
@@ -59,6 +59,9 @@ library
                , text
                , filepath
                , deepseq >= 1.2
+               , xml
+               , hxt
+               , ansi-wl-pprint
 
 Executable fontytest
     default-language:    Haskell2010
@@ -72,4 +75,7 @@ Executable fontytest
                  , vector
                  , filepath
                  , binary
+                 , xml
+                 , hxt
+                 , ansi-wl-pprint
 

--- a/FontyFruity.cabal
+++ b/FontyFruity.cabal
@@ -58,10 +58,8 @@ library
                , directory
                , text
                , filepath
-               , deepseq >= 1.2
-               , xml
-               , hxt
-               , ansi-wl-pprint
+               , deepseq    >= 1.2
+               , xml        >= 1.3
 
 Executable fontytest
     default-language:    Haskell2010
@@ -75,7 +73,4 @@ Executable fontytest
                  , vector
                  , filepath
                  , binary
-                 , xml
-                 , hxt
-                 , ansi-wl-pprint
 

--- a/src/Graphics/Text/TrueType/FontFolders.hs
+++ b/src/Graphics/Text/TrueType/FontFolders.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 module Graphics.Text.TrueType.FontFolders
     ( loadUnixFontFolderList
     , loadWindowsFontFolderList
@@ -14,134 +14,65 @@ module Graphics.Text.TrueType.FontFolders
     ) where
 
 #if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative             ((<$>), (<*>))
+import Control.Applicative( (<*>), (<$>) )
 #endif
 
 #if !MIN_VERSION_base(4,6,0)
-import           Control.Exception               (tryJust)
-import           Control.Monad                   (guard)
-import           System.Environment              (getEnv)
-import           System.IO.Error                 (isDoesNotExistError)
+import Control.Monad( guard )
+import Control.Exception( tryJust )
+import System.IO.Error( isDoesNotExistError )
+import System.Environment( getEnv )
 #else
-import           System.Environment              (lookupEnv)
+import System.Environment( lookupEnv )
 #endif
 
-import           Control.Monad                   (replicateM, when)
-import           Data.Binary                     (Binary (..))
-import           Data.Binary.Get                 (Get, getByteString,
-                                                  getWord32be)
-import           Data.Binary.Put                 (Put, putByteString,
-                                                  putWord32be)
-import qualified Data.ByteString                 as B
-import qualified Data.Map.Strict                 as M
-import           System.Directory                (doesDirectoryExist,
-                                                  doesFileExist,
-                                                  getDirectoryContents,
-                                                  getHomeDirectory)
-import           System.FilePath                 ((</>))
+import Control.Monad( when, replicateM )
+import System.Directory( getDirectoryContents
+                       , getHomeDirectory
+                       , doesDirectoryExist
+                       , doesFileExist
+                       )
+import qualified Data.ByteString as B
+import Data.Binary( Binary( .. ) )
+import Data.Binary.Get( Get
+                      , getWord32be
+                      , getByteString 
+                      )
+import Data.Binary.Put( Put
+                      , putWord32be
+                      , putByteString )
+import qualified Data.Map.Strict as M
+import System.FilePath( (</>) )
 
--- import           Text.XML.HXT.Core               (getChildren, getText, hasName,
---                                                   isElem, multi, no,
---                                                   readDocument, runX,
---                                                   withSubstDTDEntities,
---                                                   withValidate, (>>>))
+import Text.XML.Light( elChildren
+                     , elName
+                     , onlyElems
+                     , parseXML
+                     , qName
+                     , strContent )
 
-import qualified Text.XML.Light                  as X
+import qualified Control.Exception as E
+import qualified Data.Text as T
+import qualified Data.Text.IO as T (readFile)
 
-import qualified Control.Exception               as E
-import qualified Data.Text                       as T
-import qualified Data.Text.IO                    as T
+import Graphics.Text.TrueType.FontType
+import Graphics.Text.TrueType.Header
+import Graphics.Text.TrueType.Name
 
-import           Control.DeepSeq                 (($!!))
-import           Debug.Trace
-
-import           Graphics.Text.TrueType.FontType
-import           Graphics.Text.TrueType.Header
-import           Graphics.Text.TrueType.Name
-
-import           Data.Foldable                   (toList)
-import           Data.Function                   ((&))
-
-import           Text.PrettyPrint.ANSI.Leijen    (Pretty (pretty))
-import qualified Text.PrettyPrint.ANSI.Leijen    as PP
-
-import           Data.List                       (intersperse)
-import           Data.Monoid
-
-import           System.IO.Unsafe
-
-intercalate :: (Monoid a) => a -> [a] -> a
-intercalate e xs = mconcat $ intersperse e xs
-
-instance Pretty X.QName where
-  pretty (X.QName n _ _) = PP.string n
-
-instance Pretty X.Attr where
-  pretty (X.Attr k v) = PP.cyan (pretty k) <> "=" <> PP.red (PP.dquotes (PP.string v))
-
-instance Pretty X.CData where
-  pretty = go
-    where
-      go (X.CData X.CDataText     s _) = textPP s -- should escape though
-      go (X.CData X.CDataVerbatim s _) = "<![CDATA[" <> cdataPP s <> "]]>"
-      go (X.CData X.CDataRaw      s _) = rawPP s
-      textPP  = PP.string
-      cdataPP = PP.string
-      rawPP   = PP.string
-
-instance Pretty X.Content where
-  pretty (X.Elem el)  = pretty el
-  pretty (X.Text cd)  = pretty cd
-  pretty (X.CRef str) = PP.onyellow $ PP.string str
-
-instance Pretty X.Element where
-  pretty (X.Element name attrs contents _) = PP.flatAlt multiLine oneLine
-    where
-      oneLine = openTagPP <> contentsPP <> closeTagPP
-      multiLine = openTagPP <> PP.hardline <> contentsPP <> PP.hardline <> closeTagPP
-      attrsPP = mconcat $ map ((PP.space <>) . pretty) attrs
-      openTagPP  = PP.blue $ PP.langle <> pretty name <> attrsPP <> PP.rangle
-      closeTagPP = PP.blue $ PP.langle <> "/" <> pretty name <> PP.rangle
-      contentsPP = let cs = map pretty contents
-                   in PP.indent 1 $ PP.flatAlt (PP.vcat cs) (PP.sep cs)
+import Control.DeepSeq (($!!))
+import Data.Function ((&))
 
 catchAny :: IO a -> (E.SomeException -> IO a) -> IO a
 catchAny = E.catch
 
-prettyPrint :: (Pretty p) => p -> IO ()
-prettyPrint = PP.putDoc . pretty
-
-prettyTrace :: (Pretty p) => p -> p
-prettyTrace x = unsafePerformIO (prettyPrint x >> return x)
-
 loadParseFontsConf :: IO [FilePath]
-loadParseFontsConf = getPaths . T.pack . munchWS . T.unpack . T.map replaceWS
-                     <$> T.readFile "/etc/fonts/fonts.conf"
+loadParseFontsConf = getPaths <$> T.readFile "/etc/fonts/fonts.conf"
   where
-    munchWS (' ':' ':xs) = munchWS (' ':xs)
-    munchWS (x:xs)       = x : munchWS xs
-    munchWS []           = []
-    replaceWS '\n' = ' '
-    replaceWS '\t' = ' '
-    replaceWS x    = x
-    getPaths :: T.Text -> [FilePath]
-    getPaths s = X.parseXML s
-                 & X.onlyElems
-                 & concatMap X.elChildren
-                 & filter isDir
-                 & map X.strContent
-                 & map traceShowId
-    isDir :: X.Element -> Bool
-    isDir = (== "dir") . X.qName . X.elName
-
--- loadParseFontsConf :: IO [FilePath]
--- loadParseFontsConf = runX (readDoc "/etc/fonts/fonts.conf"
---                            >>> multi (isElem
---                                       >>> hasName "dir"
---                                       >>> getChildren
---                                       >>> getText))
---   where
---     readDoc = readDocument [withValidate no, withSubstDTDEntities no]
+    getPaths s = parseXML s
+                 & onlyElems
+                 & concatMap elChildren
+                 & filter ((== "dir") . qName . elName)
+                 & map strContent
 
 #if !MIN_VERSION_base(4,6,0)
 lookupEnv :: String -> IO (Maybe String)
@@ -155,10 +86,10 @@ lookupEnv varName = do
 loadUnixFontFolderList :: IO [FilePath]
 loadUnixFontFolderList = catchAny
                          (do conf <- loadParseFontsConf
-                             return $!! (</> "truetype") <$> conf)
-                         (const $ return [])
-    -- Quick hack, need to change XML parser to a lighter one
-    --return ["/usr/share/fonts", "/usr/local/share/fonts", "~/.fonts"]
+                             return $!! conf ++ map (</> "truetype") conf)
+                         (const $ return defaults)
+  where
+    defaults = ["/usr/share/fonts", "/usr/local/share/fonts", "~/.fonts"]
 
 loadWindowsFontFolderList :: IO [FilePath]
 loadWindowsFontFolderList = toFontFolder <$> lookupEnv "Windir"
@@ -188,7 +119,7 @@ data FontDescriptor = FontDescriptor
     { -- | The family name of the font
       _descriptorFamilyName :: !T.Text
       -- | The desired style
-    , _descriptorStyle      :: !FontStyle
+    , _descriptorStyle :: !FontStyle
     }
     deriving (Eq, Ord, Show)
 

--- a/src/Graphics/Text/TrueType/FontFolders.hs
+++ b/src/Graphics/Text/TrueType/FontFolders.hs
@@ -36,7 +36,7 @@ import qualified Data.ByteString as B
 import Data.Binary( Binary( .. ) )
 import Data.Binary.Get( Get
                       , getWord32be
-                      , getByteString 
+                      , getByteString
                       )
 import Data.Binary.Put( Put
                       , putWord32be
@@ -60,7 +60,6 @@ import Graphics.Text.TrueType.Header
 import Graphics.Text.TrueType.Name
 
 import Control.DeepSeq (($!!))
-import Data.Function ((&))
 
 catchAny :: IO a -> (E.SomeException -> IO a) -> IO a
 catchAny = E.catch
@@ -68,11 +67,11 @@ catchAny = E.catch
 loadParseFontsConf :: IO [FilePath]
 loadParseFontsConf = getPaths <$> T.readFile "/etc/fonts/fonts.conf"
   where
-    getPaths s = parseXML s
-                 & onlyElems
-                 & concatMap elChildren
-                 & filter ((== "dir") . qName . elName)
-                 & map strContent
+    getPaths s = map strContent
+                 $ filter ((== "dir") . qName . elName)
+                 $ concatMap elChildren
+                 $ onlyElems
+                 $ parseXML s
 
 #if !MIN_VERSION_base(4,6,0)
 lookupEnv :: String -> IO (Maybe String)
@@ -240,4 +239,3 @@ findFont loader fontName fontStyle = do
           font <- loader n
           findOrRest $ font >>= isMatching n
         else searchIn rest
-


### PR DESCRIPTION
Replaced the `hxt`-based parser for `/etc/fonts/fonts.conf`, which was preventing `loadParseFontsConf` from being usable, with an `xml`-based parser (presumably libraries like `xml` are what were meant by  the comment "need to change XML parser to a lighter one").

This fixes font loading in FontyFruity on NixOS (and likely GuixSD as well).

The dependency on `xml` isn't so bad either because, of  `FontyFruity`'s [six reverse dependencies][ff-rev], at least three already have transitive dependencies on `xml` (`asciidiagram`, `lp-diagrams-svg`, and `rasterific-svg`), and only two of the remaining packages seem to be remotely popular (`Rasterific` and `diagrams-rasterific`). All in all, I can only see this adding transitive dependencies to four packages on Hackage, and `xml` is a [pretty widespread and popular library anyway][xml-rev].

[ff-rev]: http://packdeps.haskellers.com/reverse/FontyFruity
[xml-rev]: http://packdeps.haskellers.com/reverse/xml