### PR TITLE
Fix glyph lookup

### DIFF
--- a/src/Graphics/Text/TrueType/LanguageIds.hs
+++ b/src/Graphics/Text/TrueType/LanguageIds.hs
@@ -19,11 +19,22 @@ import Data.Binary.Put( putWord16be )
 import Data.Word( Word16 )
 import qualified Data.Map.Strict as M
 
+-- Note [PlatformID sorting]
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~
+--
+-- Unicode and Windows are the two preferred encodings according to Apple's
+-- documentation. Indeed some fonts (e.g., Bitstream Vera Mono) return the wrong
+-- glyphs if we use Macintosh encoding instead of Windows one.
+--
+-- To fix this, the Ord instance for PlatformId ensures that:
+--    Unicode < Windows < Macintosh
+-- 
+
 data PlatformId
-    = PlatformUnicode   -- ^ 0
+    = PlatformUnicode   -- ^ 0 Don't change the ordering (see Note [PlatformID sorting])
+    | PlatformWindows   -- ^ 3 
     | PlatformMacintosh -- ^ 1
     | PlatformISO       -- ^ 2
-    | PlatformWindows   -- ^ 3
     | PlatformCustom    -- ^ 4
     | PlatformId Word16
     deriving (Eq, Ord, Show)


### PR DESCRIPTION
When fonts have several cmaps, we must prefer cmaps with the Unicode or Windows platformID over the Macintosh's ones: their use is discouraged in Apple's TrueType reference manual and they return wrong glyphs.

This patch fixes the Ord instance of platformID to fix this.

Here are two screenshots before and after the patch showing the 255 glyphs corresponding to the first 255 Unicode characters and using Bitstream Vera Mono [Bold]. We can see that before the patch,  glyphs of characters codes greater than 0xA2 don't correspond to the [Unicode BMP](https://en.wikibooks.org/wiki/Unicode/Character_reference/0000-0FFF):

![before-lookup-patch](https://user-images.githubusercontent.com/96633/27661542-eebd49f6-5c5a-11e7-9ceb-3c0182e1c5f2.png)

![after-lookup-patch](https://user-images.githubusercontent.com/96633/27661543-eec16b1c-5c5a-11e7-89d9-2ea417c82cdd.png)

