### PR TITLE
Support GHC-8.8.1

### DIFF
--- a/src/Graphics/Text/TrueType/CharacterMap.hs
+++ b/src/Graphics/Text/TrueType/CharacterMap.hs
@@ -102,7 +102,7 @@ instance NFData CharacterMaps where
   rnf (CharacterMaps maps) = rnf maps `seq` ()
 
 instance Binary CharacterMaps where
-  put _ = fail "Unimplemented"
+  put _ = error "Unimplemented"
   get = do
       startIndex <- bytesRead
       versionNumber <- getWord16be
@@ -113,7 +113,7 @@ instance Binary CharacterMaps where
           third (_, _, t) = t
       tableDesc <-
           sortBy (comparing third) <$> replicateM tableCount descFetcher
-          
+
 
       let fetcher (allMaps, lst) (platformId, platformSpecific, offset)
               | M.member offset allMaps = case M.lookup offset allMaps of
@@ -128,7 +128,7 @@ instance Binary CharacterMaps where
               mapData <- get
               let charMap = CharacterMap platformId platformSpecific mapData
               return (M.insert offset mapData allMaps, charMap : lst)
- 
+
       (_, tables) <- foldM fetcher (M.empty, []) tableDesc
       return . CharacterMaps $ sortBy (comparing _charMap) tables
 
@@ -173,7 +173,7 @@ findCharGlyph (CharacterMaps charMaps) langId character =
                 , let m = _charMap allMap
                 , isLangCompatible m]
   where
-    isLangCompatible v = tableLang == 0 || tableLang == langId 
+    isLangCompatible v = tableLang == 0 || tableLang == langId
       where tableLang = charTableMap langIdOfCharMap v
 
 instance Ord CharacterTable where
@@ -192,7 +192,7 @@ instance Ord CharacterTable where
     compare _ _ = GT
 
 instance Binary CharacterTable where
-    put _ = fail "Binary.put CharacterTable - Unimplemented"
+    put _ = error "Binary.put CharacterTable - Unimplemented"
     get = do
       format <- getWord16be
       case format of
@@ -301,11 +301,11 @@ instance CharMappeable Format0 where
     | ic > VU.length table = 0
     | otherwise = fromIntegral $ table VU.! ic
         where ic = fromEnum v
-        
+
   langIdOfCharMap = _format0Language
 
 instance Binary Format0 where
-    put _ = fail "Binary.Format0.put - unimplemented"
+    put _ = error "Binary.Format0.put - unimplemented"
     get = do
         tableSize <- getWord16be
         when (tableSize /= 262) $
@@ -347,7 +347,7 @@ instance Binary Format2SubHeader where
 
 
 instance Binary Format2 where
-    put _ = fail "Format2.put - unimplemented"
+    put _ = error "Format2.put - unimplemented"
     get = do
       _tableSize <- getWord16be
       lang <- getWord16be
@@ -376,7 +376,7 @@ instance CharMappeable Format6 where
   langIdOfCharMap = _format6Language
 
 instance Binary Format6 where
-    put _ = fail "Format6.put - unimplemented"
+    put _ = error "Format6.put - unimplemented"
     get = do
         _length <- getWord16be
         language <- getWord16be

--- a/src/Graphics/Text/TrueType/Glyph.hs
+++ b/src/Graphics/Text/TrueType/Glyph.hs
@@ -254,7 +254,7 @@ getCoords flags =
         let fetcher
               | isShort flag && isSame flag =
                   (prevCoord +) . fromIntegral <$> getWord8
-              | isShort flag = 
+              | isShort flag =
                   (prevCoord - ) . fromIntegral <$> getWord8
               | isSame flag =
                   return prevCoord
@@ -273,7 +273,7 @@ extractFlatOutline contour = zipWith (curry go) flagGroup coords
     (_, flagGroup) =
       mapAccumL (\acc v -> swap $ splitAt (VU.length v) acc) allFlags coords
 
-    go (flags, coord) 
+    go (flags, coord)
       | VU.null coord = mempty
       | otherwise = VU.fromList . (firstPoint :) $ expand mixed
       where
@@ -288,7 +288,7 @@ extractFlatOutline contour = zipWith (curry go) flagGroup coords
        expand [(onp, on, prevPoint, currPoint)]
         | onp == on = (prevPoint `midPoint` currPoint) : endJunction
         | otherwise = endJunction
-         where endJunction 
+         where endJunction
                 | on && firstOnCurve =
                     [currPoint, currPoint `midPoint` firstPoint, firstPoint]
                 | otherwise = [currPoint, firstPoint]
@@ -313,10 +313,9 @@ getSimpleOutline counterCount = do
           where breaker array ix = VU.splitAt (fromIntegral ix + 1) array
 
 instance Binary Glyph where
-    put _ = fail "Glyph.put - unimplemented"
+    put _ = error "Glyph.put - unimplemented"
     get = do
       hdr <- get
       case _glfNumberOfContours hdr of
         -1 -> Glyph hdr <$> getCompositeOutline
         n -> Glyph hdr <$> getSimpleOutline n
-

--- a/src/Graphics/Text/TrueType/Header.hs
+++ b/src/Graphics/Text/TrueType/Header.hs
@@ -45,7 +45,7 @@ instance Binary FontStyle where
         | otherwise = 0
 
   get = do
-    styleWord <- getWord16be 
+    styleWord <- getWord16be
     let bitAt = testBit styleWord
     return $ FontStyle (bitAt 0) (bitAt 1)
 
@@ -58,7 +58,7 @@ data FontHeader = FontHeader
       -- | To compute:  set it to 0, sum the entire font as
       -- ULONG, then store 0xB1B0AFBA - sum.
     , _fHdrChecksumAdjust   :: !Word32
-     
+
       -- | Should be equal to 0x5F0F3CF5.
     , _fHdrMagicNumber      :: !Word32
     , _fHdrFlags            :: !HeaderFlags
@@ -100,7 +100,7 @@ instance NFData FontHeader where
   rnf (FontHeader {}) = ()
 
 instance Binary FontHeader where
-  put _ = fail "Unimplemented"
+  put _ = error "Unimplemented"
   get =
     FontHeader <$> get <*> get <*> g32 <*> g32 <*> get
                <*> g16 <*> g64 <*> g64 <*> get <*> get
@@ -140,4 +140,3 @@ instance Binary HeaderFlags where
       putWord16be . foldl' setter 0 $ zip [0..] [a0, a1, a2, a3, a4]
         where setter acc (_, False) = acc
               setter acc (ix, True) = setBit acc ix
-

--- a/src/Graphics/Text/TrueType/MaxpTable.hs
+++ b/src/Graphics/Text/TrueType/MaxpTable.hs
@@ -12,7 +12,7 @@ import Data.Binary.Get( getWord16be )
 
 import Graphics.Text.TrueType.Types
 
-data MaxpTable = MaxpTable 
+data MaxpTable = MaxpTable
     { -- | version number	0x00010000 for version 1.0.
       _maxpTableVersion :: !Fixed
     -- | The number of glyphs in the font.
@@ -29,7 +29,7 @@ data MaxpTable = MaxpTable
     , _maxpmaxZones :: !Word16
     -- | Maximum points used in Z0.
     , _maxpmaxTwilightPoints :: !Word16
-    -- | Number of Storage Area locations. 
+    -- | Number of Storage Area locations.
     , _maxpmaxStorage :: !Word16
     -- | Number of FDEFs.
     , _maxpmaxFunctionDefs :: !Word16
@@ -50,10 +50,9 @@ instance NFData MaxpTable where
     rnf (MaxpTable {}) = ()
 
 instance Binary MaxpTable where
-    put _ = fail "Unimplemented"
-    get = MaxpTable 
+    put _ = error "Unimplemented"
+    get = MaxpTable
        <$> get <*> g16 <*> g16 <*> g16 <*> g16 <*> g16
        <*> g16 <*> g16 <*> g16 <*> g16 <*> g16 <*> g16
        <*> g16 <*> g16 <*> g16
          where g16 = getWord16be
-

--- a/src/Graphics/Text/TrueType/Name.hs
+++ b/src/Graphics/Text/TrueType/Name.hs
@@ -35,7 +35,7 @@ instance NFData NameTable where
     rnf (NameTable {}) = ()
 
 instance Binary NameTable where
-  put _ = fail "Binary.put NameTable - unimplemented"
+  put _ = error "Binary.put NameTable - unimplemented"
   get = do
     nameFormatId <- getWord16be
     when (nameFormatId /= 0) $
@@ -110,13 +110,11 @@ fontFamilyName (NameTable { _ntRecords = records }) =
       _nrPlatformSpecificId r == semanticUnicode2
 
 instance Binary NameRecords where
-  get = NameRecords <$> g16 <*> g16 <*> g16 
-                    <*> g16 <*> g16 <*> g16 
+  get = NameRecords <$> g16 <*> g16 <*> g16
+                    <*> g16 <*> g16 <*> g16
                     <*> pure mempty
       where g16 = getWord16be
 
   put (NameRecords p ps l n len ofs _) =
       p16 p >> p16 ps >> p16 l >> p16 n >> p16 len >> p16 ofs
     where p16 = putWord16be
-
-


### PR DESCRIPTION
`MonadFail` is no longer a super-class of `Monad`, and `Data.Binary.Put` does not have `MonadFail` as a super-class. As a result, `fail` cannot be called in the `put` function. To solve this, all references to `fail` are replaced with `error`. This may not be the ideal way to handle anyone who attempts to use `put`, but seems the simplest change to make.

(Also some miscellaneous whitespace removal by my editor.)