### PR TITLE
Fix font spacing + apply kerning

### DIFF
--- a/FontyFruity.cabal
+++ b/FontyFruity.cabal
@@ -37,6 +37,7 @@ library
                , Graphics.Text.TrueType.MaxpTable
                , Graphics.Text.TrueType.Header
                , Graphics.Text.TrueType.Glyph
+               , Graphics.Text.TrueType.Kerning
                , Graphics.Text.TrueType.Types
                , Graphics.Text.TrueType.OffsetTable
                , Graphics.Text.TrueType.CharacterMap

--- a/src/Graphics/Text/TrueType/FontType.hs
+++ b/src/Graphics/Text/TrueType/FontType.hs
@@ -14,6 +14,7 @@ import Graphics.Text.TrueType.Glyph
 import Graphics.Text.TrueType.Header
 import Graphics.Text.TrueType.OffsetTable
 import Graphics.Text.TrueType.CharacterMap
+import Graphics.Text.TrueType.Kerning
 import Graphics.Text.TrueType.HorizontalInfo
 import Graphics.Text.TrueType.Name
 
@@ -28,6 +29,7 @@ data Font = Font
  , _fontHeader            :: Maybe FontHeader
  , _fontMaxp              :: Maybe MaxpTable
  , _fontMap               :: Maybe CharacterMaps
+ , _fontKerning           :: Maybe KernTable
  , _fontGlyph             :: Maybe (V.Vector Glyph)
  , _fontLoca              :: Maybe (VU.Vector Word32)
  , _fontHorizontalHeader  :: Maybe HorizontalHeader
@@ -53,6 +55,7 @@ emptyFont table = Font
     , _fontMaxp              = Nothing
     , _fontLoca              = Nothing
     , _fontMap               = Nothing
+    , _fontKerning           = Nothing
     , _fontHorizontalHeader  = Nothing
     , _fontHorizontalMetrics = Nothing
     }

--- a/src/Graphics/Text/TrueType/Kerning.hs
+++ b/src/Graphics/Text/TrueType/Kerning.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE CPP #-}
+module Graphics.Text.TrueType.Kerning
+  ( KernTable
+  , getKerningValue
+  ) where
+
+import Control.DeepSeq( NFData( .. ) )
+import Control.Monad (replicateM, when)
+import Data.Bits( (.&.) )
+import Data.Binary( Binary( .. ) )
+import Data.Binary.Get( Get
+                      , getWord16be
+                      , getInt16be
+                      , skip
+                      )
+import Data.Int( Int16 )
+import qualified Data.Map.Strict as M
+import Data.Maybe( fromMaybe )
+import Data.Word( Word16 )
+
+data KernTable = KernTable
+  { _kernPairs :: M.Map (Word16, Word16) Int16 } 
+  deriving (Eq, Show)
+
+instance NFData KernTable where
+  rnf (KernTable {}) = ()
+
+instance Binary KernTable where
+  put = error "Binary.put KernTable - unimplemented"
+  get = getKern
+
+getKern :: Get KernTable
+getKern = do
+  version <- getWord16be
+  case version of
+    0 -> getKernV0
+    1 -> getKernV1
+    v -> fail $ "Unsupported kern table version " <> show v
+
+-- Windows kern table
+getKernV0 :: Get KernTable
+getKernV0 = do
+  skip 2 -- skip nTables
+  subtableVersion <- getWord16be 
+  when (subtableVersion /= 0) $
+    fail $ "Unsupported kern subtable version " <> show subtableVersion
+  skip 4 -- skip subtableLength, subtableCoverage
+  nPairs <- getWord16be
+  skip 6 -- skip searchRange, entrySelector, rangeShift
+  pairs <- replicateM (fromIntegral nPairs) getPair
+  return $ KernTable $ M.fromList pairs
+
+-- Mac kern table
+getKernV1 :: Get KernTable
+getKernV1 = do
+  skip 2 -- skip 16 bits because version 1 uses 32-bit version but we only consumed 16.
+  skip 4 -- skip nTables
+  skip 4 -- skip length of subtable
+  coverage <- getWord16be
+  let subtableVersion = coverage .&. 0x00FF
+  skip 2 -- skip tupleIndex subtable header
+  if subtableVersion == 0
+    then do
+      nPairs <- getWord16be
+      skip 6 -- skip searchRange, entrySelector, rangeShift
+      pairs <- replicateM (fromIntegral nPairs) getPair
+      return $ KernTable $ M.fromList pairs
+    else return $ KernTable mempty
+
+getPair :: Get ((Word16, Word16), Int16)
+getPair = do
+  left <- getWord16be
+  right <- getWord16be
+  value <- getInt16be
+  return ((left, right), value)
+
+getKerningValue
+  :: (Integral v)
+  => Word16 -- left glyph index
+  -> Word16 -- right glyph index
+  -> KernTable
+  -> v -- value added to advance width
+getKerningValue l r = 
+  fromIntegral . fromMaybe 0 . M.lookup (l, r) . _kernPairs


### PR DESCRIPTION
- Change spacing from (x + bearing + advance) to (x + advance). Advance already includes left side bearing.
- Parse kern pairs table and apply kerning.

Before:
<img width="470" alt="Screen Shot 2022-01-06 at 11 02 16 AM" src="https://user-images.githubusercontent.com/1112718/148328629-ad6c7388-6810-4f13-815b-eee553fe9167.png">

After:
<img width="470" alt="Screen Shot 2022-01-06 at 10 59 10 AM" src="https://user-images.githubusercontent.com/1112718/148328632-39198d9f-a081-40ae-bb48-c099bbb29d0a.png">

