### PR TITLE
bracket lazy I/O

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-dist
+dist*
 .cabal-sandbox
 *.swp
 *.swo


### PR DESCRIPTION
just got a macbook, discovered that using lazy I/O here was leaving a ton of file descriptors open and causing crashes because the default maximum number of file descriptors for a program is 256. this PR fixed that for me.